### PR TITLE
FIX PROBLEM WITH dolfin FUNCTION MeshEditor().open()

### DIFF
--- a/magnummsh/inp_utils.py
+++ b/magnummsh/inp_utils.py
@@ -50,7 +50,7 @@ class INPReader(object):
       self._need_update = False
       editor = MeshEditor()
       self._mesh = Mesh()
-      editor.open(self._mesh, 3, 3)
+      editor.open(self._mesh, "tetrahedron", 3, 3)
       editor.init_vertices(len(self.nodes))
       editor.init_cells(len(self.elements))
       map(lambda x: editor.add_vertex(x[0]-1, np.array([x[1], x[2], x[3]])), self.nodes)

--- a/magnummsh/mesh_utils.py
+++ b/magnummsh/mesh_utils.py
@@ -52,7 +52,7 @@ class MeshTool(object):
     """
     editor = MeshEditor()
     newmesh = Mesh()
-    editor.open(newmesh, 3, 3)
+    editor.open(newmesh, "tetrahedron", 3, 3)
     if self._mesh is None:
       N = 0
       NE = 0


### PR DESCRIPTION
Fix problem dolfin function MeshEditor().open() that requires an
explicit specification of CellType since version 2017.2.0. Included
CellType "tetrahedron" in every call of MeshEditor().open()